### PR TITLE
Add stats endpoint

### DIFF
--- a/server/flb_manager.ts
+++ b/server/flb_manager.ts
@@ -13,6 +13,7 @@ interface FlbManager {
   write: (instanceId: string, data: string) => void;
   disconnect: (userId: string, socket: WebSocket) => void
   disconnectAll: () => void
+  count: () => number
 }
 
 interface FlbInstance {
@@ -174,6 +175,10 @@ export default function flbManager(): FlbManager {
         instance.disconnectAll();
         instances.delete(userId);
       }
+    },
+
+    count() {
+      return instances.size
     }
   }
 }


### PR DESCRIPTION
This endpoint returns the number of websocket connections and fluent-bit instances. Can also be used as a simple health check.

Here's a simple way to use it: `curl http://localhost:5489/stats`

