### PR TITLE
server: provide healthcheck endpoint

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -17,6 +17,23 @@ const nextHandle = nextApp.getRequestHandler()
 const app = express()
 .use(bodyParser.json({limit: 1024 * 1024 * 10}))
 
+let healthy = false
+
+app.get('/healthz', (_req, res) => {
+  if (healthy) {
+    res.status(200).json({
+      uptime: process.uptime(),
+      message: 'OK',
+      timestamp: Date.now()
+    })
+  } else {
+    res.status(503).json({
+      uptime: process.uptime(),
+      message: 'NOK',
+      timestamp: Date.now()
+    })
+  }
+});
 
 let websocketConnections = 0
 
@@ -78,10 +95,12 @@ async function start() {
   server.listen(port, (err?: Error) =>{
     if (err) throw err
     console.log(`> Ready on http://${hostname}:${port}`)
+    healthy = true
   })
 }
 
 start().catch(err => {
+  healthy = false
   console.error(err)
   process.exit(1)
 })

--- a/vivo-k8s.yaml
+++ b/vivo-k8s.yaml
@@ -40,7 +40,17 @@ spec:
         - image: ghcr.io/calyptia/vivo
           name: vivo
           ports:
-            - containerPort: 5489
-            - containerPort: 24224
+            - name: http-port
+              containerPort: 5489
+            - name: forward-port
+              containerPort: 24224
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http-port
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          # We really should provide resource limits
           resources: {}
       restartPolicy: Always


### PR DESCRIPTION
Simple healthcheck endpoint provided that only marks as ready once server is listening.
Updated YAML to use it, this should handle automated testing as well so resolves #1 now.

Signed-off-by: Patrick Stephens <pat@calyptia.com>