### PR TITLE
Implement --single-user command line option

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "body-parser": "^1.20.1",
+    "commander": "^9.4.1",
     "express": "^4.18.2",
     "next": "12.3.1",
     "react": "18.2.0",

--- a/server/flb_manager.ts
+++ b/server/flb_manager.ts
@@ -3,22 +3,25 @@ import cp from 'child_process'
 import crypto from 'crypto'
 import split2 from 'split2'
 
-import { WebSocket } from 'ws'
 import { FluentBitOpts } from '../common/types'
 
 const FLUENT_BIT_EXEC_PATH = process.env.FLUENT_BIT_EXEC_PATH || '/fluent-bit/bin/fluent-bit';
 
+export interface Socket {
+  send: (json: string) => void;
+}
+
 interface FlbManager {
-  connect: (userId: string, datasocket: WebSocket, opts: FluentBitOpts) => string
+  connect: (userId: string, datasocket: Socket, opts: FluentBitOpts) => string
   write: (instanceId: string, data: string) => void;
-  disconnect: (userId: string, socket: WebSocket) => void
+  disconnect: (userId: string, socket: Socket) => void
   disconnectAll: () => void
   count: () => number
 }
 
 interface FlbInstance {
-  connect: (socket: WebSocket) => void;
-  disconnect: (socket: WebSocket) => void;
+  connect: (socket: Socket) => void;
+  disconnect: (socket: Socket) => void;
   write: (data: string) => void;
   disconnectAll: () => void;
   connectedCount: () => number;
@@ -30,7 +33,7 @@ function generateToken() {
 };
 
 function spawnFluentBit({ datasource }: FluentBitOpts): FlbInstance {
-  const sockets = new Set<WebSocket>()
+  const sockets = new Set<Socket>()
 
   const ds = datasource === 'http' ? 'stdin' : datasource
 
@@ -49,9 +52,7 @@ function spawnFluentBit({ datasource }: FluentBitOpts): FlbInstance {
     }
     const json = JSON.stringify(payload)
     for (const socket of sockets) {
-      if (socket.readyState === WebSocket.OPEN) {
-        socket.send(json)
-      }
+      socket.send(json)
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,6 +564,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+commander@^9.4.1:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
+  integrity sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
Passing this option will result in a separate fluent-bit instance to be spawned on startup, with any events emitted to it being forwarded to vivo's stderr (prefixed by "fluent-bit:").

When the option is passed, an additional "/console" endpoint is created, which can be used to post data to the underlying fluent-bit instance.

close #12 

@patrick-stephens this was the simplest way I found to implement a single user mode without too much refactor of the existing code.

