### PR TITLE
dockerfiles: use slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ USER node
 RUN yarn install && yarn build
 RUN ./node_modules/.bin/tsc --noEmit false --outDir tsbuild
 
-FROM node:18 as prod
+FROM node:18-slim as prod
 
 WORKDIR /app
 


### PR DESCRIPTION
Reduce the size of the runtime images.

Signed-off-by: Patrick Stephens <pat@calyptia.com>