### PR TITLE
Feature | Add a pull request template to Vivo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+Fixes: #ISSUE_NUMBER
+
+## Description of changes
+
+TODO
+
+<!-- Provide an explanation of what's changing in this PR. Include replication notes for bugs, and screenshots where appropriate. -->
+<!-- If your PR is based on a Github Issue, the title of the PR should look like `#NNN | Pull Request Title`. Please *also* include a link to the Github Issue in your PR body. -->
+
+## Notes for code reviewers
+
+TODO
+
+<!--
+If there's things code reviewers should know about how you have structured your change, put them here.
+
+If you don't know who should review your code, start with the recommended reviewers in Github.
+-->
+
+## Notes for testing
+
+TODO
+
+<!-- Provide notes on how reviewers can test your changes. For example, what are good accounts to test in, which specific links should they test from, and what
+functionality should be tested. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
-Fixes: #ISSUE_NUMBER
+Fixes:
+- [ASANA Ticket Title](https://app.asana.com/0/1203769814255679/board)
 
 ## Description of changes
 
@@ -16,10 +17,3 @@ If there's things code reviewers should know about how you have structured your 
 
 If you don't know who should review your code, start with the recommended reviewers in Github.
 -->
-
-## Notes for testing
-
-TODO
-
-<!-- Provide notes on how reviewers can test your changes. For example, what are good accounts to test in, which specific links should they test from, and what
-functionality should be tested. -->


### PR DESCRIPTION
Fixes: [1204687823638800](https://app.asana.com/0/1203879107682284/1204687823638800)

## Description of changes

Adds a template to pull requests for Vivo, like we have in Core.

## Notes for code reviewers

Documentation: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository 

## Notes for testing

Not sure how to test this, except by comparing the configuration to the one we have in frontend. It wont kick in until it is merged.