### PR TITLE
Redirect "/" to vivo base path

### DIFF
--- a/packages/service/vivo.go
+++ b/packages/service/vivo.go
@@ -50,6 +50,10 @@ func VivoListen(frontendStaticDir string, basePath string) {
 	basePath += "/"
 	fs := http.StripPrefix(basePath, http.FileServer(http.Dir(frontendStaticDir)))
 	http.Handle(basePath, fs)
+	if basePath != "/" {
+		// redirect "/" to base path
+		http.Handle("/", http.RedirectHandler(basePath, http.StatusSeeOther))
+	}
 	http.HandleFunc(basePath+"logs", vivoForward)
 	http.HandleFunc(basePath+"metrics", vivoForward)
 	http.HandleFunc(basePath+"traces", vivoForward)


### PR DESCRIPTION
When vivo base path is different than "/" (root path), setup a redirect handler in the golang proxy.

@edsiper This allows the user to type `localhost:8000/` in the browser to access vivo UI.

Close #205
