### PR TITLE
Set vivo service type to "NodePort"

### DIFF
--- a/vivo-deployment.yaml
+++ b/vivo-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/instance: calyptia
   name: calyptia-vivo
 spec:
+  type: NodePort
   ports:
     - name: "forward"
       port: 9000


### PR DESCRIPTION
This is required for the service to be reachable in docker desktop extension.

Required for fixing [docker-desktop-extension: vivo ui not working](https://app.asana.com/0/1205296323611471/1205226608839625/f)
